### PR TITLE
Fix missing ExcelHelper namespace import

### DIFF
--- a/EmployeeManagementApi/Controllers/DepartmentsController.cs
+++ b/EmployeeManagementApi/Controllers/DepartmentsController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using EmployeeManagementApi.Data;
 using EmployeeManagementApi.Models;
+using EmployeeManagementApi.Services;
 
 namespace EmployeeManagementApi.Controllers;
 


### PR DESCRIPTION
## Summary
- import `EmployeeManagementApi.Services` in `DepartmentsController`

## Testing
- `dotnet build --no-restore` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_6865158a24dc832d8e03f9fb1decdc3f