### PR TITLE
Enable Swagger in all environments

### DIFF
--- a/EmployeeManagementApi/Program.cs
+++ b/EmployeeManagementApi/Program.cs
@@ -31,11 +31,10 @@ builder.Services.AddControllers();
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.
-if (app.Environment.IsDevelopment())
-{
-    app.UseSwagger();
-    app.UseSwaggerUI();
-}
+// Swagger UI is enabled for all environments so that the API
+// documentation is always available.
+app.UseSwagger();
+app.UseSwaggerUI();
 
 app.UseHttpsRedirection();
 

--- a/SWAGGER.md
+++ b/SWAGGER.md
@@ -1,0 +1,13 @@
+# Swagger Usage
+
+Swagger UI is enabled in all environments.
+
+After running the API you can access the interactive documentation at:
+
+```
+http://localhost:{port}/swagger
+```
+
+Replace `{port}` with the port number the application is listening on. For typical `dotnet run` defaults this is `https://localhost:5001/swagger` or `http://localhost:5000/swagger`.
+
+Use this URL to explore and interact with the available API endpoints.


### PR DESCRIPTION
## Summary
- make Swagger UI available for all environments
- document Swagger URL in `SWAGGER.md`

## Testing
- `dotnet build -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_b_68651a0f8d2c832dbf5c4d39e9c6ddd3