### PR TITLE
Add database health endpoint

### DIFF
--- a/EmployeeManagementApi/Controllers/HealthController.cs
+++ b/EmployeeManagementApi/Controllers/HealthController.cs
@@ -1,0 +1,40 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using EmployeeManagementApi.Data;
+using EmployeeManagementApi.Models;
+
+namespace EmployeeManagementApi.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class HealthController : ControllerBase
+{
+    private readonly AppDbContext _context;
+
+    public HealthController(AppDbContext context)
+    {
+        _context = context;
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<HealthCheckResult>> Get()
+    {
+        var result = new HealthCheckResult
+        {
+            ConnectionString = _context.Database.GetConnectionString()
+        };
+        try
+        {
+            result.CanConnect = await _context.Database.CanConnectAsync();
+            result.Employees = await _context.Employees
+                .Take(10)
+                .ToListAsync();
+        }
+        catch (Exception ex)
+        {
+            result.CanConnect = false;
+            result.Exception = ex.ToString();
+        }
+        return Ok(result);
+    }
+}

--- a/EmployeeManagementApi/Models/HealthCheckResult.cs
+++ b/EmployeeManagementApi/Models/HealthCheckResult.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace EmployeeManagementApi.Models;
+
+public class HealthCheckResult
+{
+    public string? ConnectionString { get; set; }
+    public bool CanConnect { get; set; }
+    public List<Employee>? Employees { get; set; }
+    public string? Exception { get; set; }
+}


### PR DESCRIPTION
## Summary
- create model `HealthCheckResult` to describe health data
- add new `HealthController` API to expose `/api/health`

## Testing
- `dotnet build EmployeeManagementApi/EmployeeManagementApi.csproj -v q`
- `dotnet test EmployeeManagementApi/EmployeeManagementApi.csproj`


------
https://chatgpt.com/codex/tasks/task_b_68652107e430832d89696356c0f795bb