### PR TITLE
Improve SQLite connection configuration

### DIFF
--- a/EmployeeManagementApi/Program.cs
+++ b/EmployeeManagementApi/Program.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Data.Sqlite;
 using EmployeeManagementApi.Data;
 using EmployeeManagementApi.Services;
 
@@ -16,10 +17,20 @@ if (useSqlServer)
 }
 else
 {
-    var dbPath = Path.Combine(builder.Environment.ContentRootPath, "DataFiles", "employeedb.db");
-    Directory.CreateDirectory(Path.GetDirectoryName(dbPath)!);
+    var connectionString = builder.Configuration.GetConnectionString("DefaultConnection")
+                         ?? "Data Source=DataFiles/employeedb.db";
+
+    var sqliteBuilder = new SqliteConnectionStringBuilder(connectionString);
+
+    if (!Path.IsPathRooted(sqliteBuilder.DataSource))
+    {
+        sqliteBuilder.DataSource = Path.Combine(builder.Environment.ContentRootPath, sqliteBuilder.DataSource);
+    }
+
+    Directory.CreateDirectory(Path.GetDirectoryName(sqliteBuilder.DataSource)!);
+
     builder.Services.AddDbContext<AppDbContext>(options =>
-        options.UseSqlite($"Data Source={dbPath}"));
+        options.UseSqlite(sqliteBuilder.ToString()));
 }
 
 builder.Services.AddScoped<ExcelHelper>();


### PR DESCRIPTION
## Summary
- use the `DefaultConnection` string to build the SQLite path
- resolve relative paths using `SqliteConnectionStringBuilder`

## Testing
- `dotnet build EmployeeManagementApi/EmployeeManagementApi.csproj -v minimal` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6865321cbcbc832d9d197aa9107e9c8c