### PR TITLE
Include db file in publish output

### DIFF
--- a/EmployeeManagementApi/EmployeeManagementApi.csproj
+++ b/EmployeeManagementApi/EmployeeManagementApi.csproj
@@ -14,4 +14,9 @@
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="ClosedXML" Version="0.102.1" />
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="DataFiles\**\*">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- ensure `DataFiles` content is copied to the output

## Testing
- `dotnet publish EmployeeManagementApi/EmployeeManagementApi.csproj -c Release -o pubdir` *(fails: `dotnet` not installed)*

------
https://chatgpt.com/codex/tasks/task_b_6865347105fc832d9832c28e48bbf05b