### PR TITLE
Replace deprecated config-zip deployment

### DIFF
--- a/deploy/deploy.ps1
+++ b/deploy/deploy.ps1
@@ -38,9 +38,10 @@ Write-Host "Creating deployment archive..."
 Compress-Archive -Path (Join-Path $publishFolder '*') -DestinationPath $zipPath
 
 Write-Host "Deploying to Azure..."
-az webapp deployment source config-zip `
+az webapp deploy `
     --resource-group $ResourceGroup `
     --name $WebAppName `
-    --src $zipPath
+    --src-path $zipPath `
+    --type zip
 
 Write-Host "Deployment completed"

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -19,7 +19,8 @@ az deployment group create \
 
 zip -r app.zip EmployeeManagementApi -x "*/bin/*" "*/obj/*"
 
-az webapp deployment source config-zip \
+az webapp deploy \
   --resource-group "$RESOURCE_GROUP" \
   --name "$WEBAPP_NAME" \
-  --src app.zip
+  --src-path app.zip \
+  --type zip


### PR DESCRIPTION
## Summary
- replace `az webapp deployment source config-zip` with `az webapp deploy`
- keep deployment archive parameter and specify zip type

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68656684ef68832d9b067b9a24b99a66