### PR TITLE
Enable CORS

### DIFF
--- a/EmployeeManagementApi/Program.cs
+++ b/EmployeeManagementApi/Program.cs
@@ -40,6 +40,13 @@ builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
 builder.Services.AddControllers();
+builder.Services.AddCors(options =>
+{
+    options.AddDefaultPolicy(policy =>
+        policy.AllowAnyOrigin()
+              .AllowAnyMethod()
+              .AllowAnyHeader());
+});
 
 var app = builder.Build();
 
@@ -50,6 +57,8 @@ app.UseSwagger();
 app.UseSwaggerUI();
 
 app.UseHttpsRedirection();
+
+app.UseCors();
 
 app.UseAuthorization();
 


### PR DESCRIPTION
## Summary
- add default CORS policy that allows any origin
- use the CORS middleware

## Testing
- `dotnet build EmployeeManagementApi/EmployeeManagementApi.csproj` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_b_6865f8701324832d9803fd5f2dd603da