### PR TITLE
Add default Swagger landing page

### DIFF
--- a/EmployeeManagementApi/EmployeeManagementApi.csproj
+++ b/EmployeeManagementApi/EmployeeManagementApi.csproj
@@ -18,5 +18,8 @@
     <Content Include="DataFiles\**\*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="wwwroot\**\*">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 </Project>

--- a/EmployeeManagementApi/Program.cs
+++ b/EmployeeManagementApi/Program.cs
@@ -58,6 +58,10 @@ app.UseSwaggerUI();
 
 app.UseHttpsRedirection();
 
+// Serve default files such as index.html from wwwroot
+app.UseDefaultFiles();
+app.UseStaticFiles();
+
 app.UseCors();
 
 app.UseAuthorization();

--- a/EmployeeManagementApi/wwwroot/index.html
+++ b/EmployeeManagementApi/wwwroot/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Employee Management API</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 2em; }
+    </style>
+</head>
+<body>
+    <h1>Employee Management API</h1>
+    <p>This API provides employee data and operations. It uses <a href="https://swagger.io" target="_blank">Swagger</a> for interactive documentation.</p>
+    <p>
+        <a href="/swagger" target="_blank">Open Swagger UI</a>
+    </p>
+    <p>
+        <a href="/swagger/v1/swagger.json" target="_blank">View OpenAPI specification</a>
+    </p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- show index.html at the base URL
- copy web root files to output
- load default files and static files in the API

## Testing
- `dotnet build EmployeeManagementApi/EmployeeManagementApi.csproj -v q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6865f9979000832d98fbd49fb269ddc3