### PR TITLE
Add publish and zip script

### DIFF
--- a/build-publish-zip.ps1
+++ b/build-publish-zip.ps1
@@ -1,0 +1,33 @@
+Param(
+    [string]$Configuration = "Release"
+)
+
+$publishFolder = Join-Path $PSScriptRoot "publish"
+$zipPath = Join-Path $PSScriptRoot "app.zip"
+$projectPath = Join-Path $PSScriptRoot "EmployeeManagementApi"
+
+if (Test-Path $publishFolder) { Remove-Item $publishFolder -Recurse -Force }
+if (Test-Path $zipPath) { Remove-Item $zipPath -Force }
+
+pushd $projectPath
+
+# Restore and build the project
+dotnet restore
+
+dotnet build -c $Configuration
+
+# Publish the project to the publish folder
+popd
+
+dotnet publish $projectPath -c $Configuration -o $publishFolder
+
+# Create a zip archive with Linux compatible forward slashes
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+$zip = [System.IO.Compression.ZipFile]::Open($zipPath, [System.IO.Compression.ZipArchiveMode]::Create)
+Get-ChildItem -Recurse -File -Path $publishFolder | ForEach-Object {
+    $relativePath = $_.FullName.Substring($publishFolder.Length + 1) -replace '\\','/'
+    [System.IO.Compression.ZipFileExtensions]::CreateEntryFromFile($zip, $_.FullName, $relativePath) | Out-Null
+}
+$zip.Dispose()
+
+Write-Host "Publish directory archived at $zipPath"


### PR DESCRIPTION
## Summary
- add `build-publish-zip.ps1` to compile, publish, and archive the API with forward slashes

## Testing
- `pwsh build-publish-zip.ps1` *(fails: command not found)*
- `dotnet build EmployeeManagementApi/EmployeeManagementApi.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6866084fb32c832dacb982308f10b50f