### PR TITLE
Add simple deploy script for zipped publish

### DIFF
--- a/deploy-zip.ps1
+++ b/deploy-zip.ps1
@@ -1,0 +1,12 @@
+Param(
+    [string]$ResourceGroup = "india-app-service-rg",
+    [string]$WebAppName = "webapi-3749",
+    [string]$ZipPath = (Join-Path $PSScriptRoot 'app.zip')
+)
+
+az webapp deploy `
+  --resource-group $ResourceGroup `
+  --name $WebAppName `
+  --src-path $ZipPath `
+  --type zip
+


### PR DESCRIPTION
## Summary
- add `deploy-zip.ps1` to deploy a pre-built zip archive

## Testing
- `pwsh -NoLogo -Command "./deploy-zip.ps1 -ResourceGroup 'india-app-service-rg' -WebAppName 'webapi-3749' -ZipPath (Join-Path $PWD 'app.zip')"` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_686609dd5c68832d8e63f96c320f3af5