### PR TITLE
Fix path and variable in Run-WebApi script

### DIFF
--- a/scripts/Run-WebApi.ps1
+++ b/scripts/Run-WebApi.ps1
@@ -2,19 +2,23 @@
 
 [CmdletBinding()]
 param(
-    [string]$ProjectPath = "../EmployeeManagementApi/EmployeeManagementApi.csproj",
+    [string]$ProjectPath,
     [string]$BaseUrl = "http://localhost:5000"
 )
+
+if (-not $ProjectPath) {
+    $ProjectPath = Join-Path $PSScriptRoot "../EmployeeManagementApi/EmployeeManagementApi.csproj"
+}
 
 function Wait-Port {
     param([string]$Url)
     $uri = [System.Uri]$Url
-    $host = $uri.Host
+    $hostName = $uri.Host
     $port = $uri.Port
     while ($true) {
         try {
             $client = New-Object System.Net.Sockets.TcpClient
-            $client.Connect($host, $port)
+            $client.Connect($hostName, $port)
             $client.Dispose()
             break
         } catch {


### PR DESCRIPTION
## Summary
- update project path logic in Run-WebApi script
- rename `$host` variable to avoid conflicts

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68681c723d48832d8bffe6f214520e4e