### PR TITLE
Fix Deploy-WebApi zip paths

### DIFF
--- a/scripts/Deploy-WebApi.ps1
+++ b/scripts/Deploy-WebApi.ps1
@@ -18,8 +18,14 @@ Write-Host "Publishing application..." -ForegroundColor Cyan
 
 if (Test-Path $zipPath) { Remove-Item $zipPath }
 
-# Create the deployment package
-Compress-Archive -Path "$publishDir/*" -DestinationPath $zipPath -Force
+# Create the deployment package with consistent forward slashes
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+[System.IO.Compression.ZipFile]::CreateFromDirectory(
+    $publishDir,
+    $zipPath,
+    [System.IO.Compression.CompressionLevel]::Optimal,
+    $false
+)
 
 if (-not (az group exists --name $ResourceGroup)) {
     Write-Host "Creating resource group $ResourceGroup" -ForegroundColor Cyan

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -38,3 +38,7 @@ Publishes the EmployeeManagementApi project and deploys it to an Azure App Servi
 ```
 
 Parameters allow overriding the resource group, plan and app name. The default app name is **eastasia-webapi**.
+
+The deployment package is generated using the .NET `ZipFile` API so the entries
+within the archive always use forward slashes. This ensures compatibility across
+different operating systems.


### PR DESCRIPTION
## Summary
- use `ZipFile.CreateFromDirectory` in `Deploy-WebApi.ps1`
- document zip behavior in script README

## Testing
- `dotnet build web-api-with-codex.sln` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_b_6868220e2660832db778aac124b75309